### PR TITLE
Fix: Doubles game stats was referencing singles game stats as starting point

### DIFF
--- a/js/source/tablechamp.js
+++ b/js/source/tablechamp.js
@@ -755,14 +755,14 @@
             var t2p1LastMovement = t2p1PointsNew - localData.playersByKey[t2p1Key].doubles_points;
             var t2p2LastMovement = t2p2PointsNew - localData.playersByKey[t2p2Key].doubles_points;
             // Updates games won/lost
-            var t1p1GamesLost = localData.playersByKey[t1p1Key].singles_lost;
-            var t1p1GamesWon = localData.playersByKey[t1p1Key].singles_won;
-            var t1p2GamesLost = localData.playersByKey[t1p2Key].singles_lost;
-            var t1p2GamesWon = localData.playersByKey[t1p2Key].singles_won;
-            var t2p1GamesLost = localData.playersByKey[t2p1Key].singles_lost;
-            var t2p1GamesWon = localData.playersByKey[t2p1Key].singles_won;
-            var t2p2GamesLost = localData.playersByKey[t2p2Key].singles_lost;
-            var t2p2GamesWon = localData.playersByKey[t2p2Key].singles_won;
+            var t1p1GamesLost = localData.playersByKey[t1p1Key].doubles_lost;
+            var t1p1GamesWon = localData.playersByKey[t1p1Key].doubles_won;
+            var t1p2GamesLost = localData.playersByKey[t1p2Key].doubles_lost;
+            var t1p2GamesWon = localData.playersByKey[t1p2Key].doubles_won;
+            var t2p1GamesLost = localData.playersByKey[t2p1Key].doubles_lost;
+            var t2p1GamesWon = localData.playersByKey[t2p1Key].doubles_won;
+            var t2p2GamesLost = localData.playersByKey[t2p2Key].doubles_lost;
+            var t2p2GamesWon = localData.playersByKey[t2p2Key].doubles_won;
             var t1Won = false;
             var t2Won = false;
             if (parseInt(t1s) > parseInt(t2s)) {


### PR DESCRIPTION
The doubles game stats (games lost/games won) was using the singles game stats as the starting point. This resulted in the doubles games lost/games won only incrementing from the singles stats, so they weren't accurate.